### PR TITLE
forced map to edges of screen and stopped buttons from dragging map

### DIFF
--- a/streetsense/streetsense_frontend_vite/index.html
+++ b/streetsense/streetsense_frontend_vite/index.html
@@ -5,6 +5,19 @@
     <link rel="icon"  href="/ss.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>StreetSense</title>
+    <style>
+      html, body {
+        margin: 0;
+        padding: 0;
+        width: 100%;
+        height: 100%;
+        overflow: hidden;
+      }
+      #app {
+        width: 100%;
+        height: 100%;
+      }
+    </style>
   </head>
   <body>
     <div id="app"></div>

--- a/streetsense/streetsense_frontend_vite/src/App.vue
+++ b/streetsense/streetsense_frontend_vite/src/App.vue
@@ -43,11 +43,17 @@ body {
   align-items: center;
   padding: 0.5rem;
   z-index: 1000; /* Ensure the logo bar appears above the map */
+  pointer-events: none; /* Prevent dragging */
+  touch-action: none; /* Prevent dragging */
 }
 
 .logo {
   height: 50px; 
   width: auto; 
   margin-left: 0.5rem;
+}
+
+.gm-style-iw {
+  pointer-events: none; /* Disable pointer events on the info window */
 }
 </style>

--- a/streetsense/streetsense_frontend_vite/src/components/CrimeMap.vue
+++ b/streetsense/streetsense_frontend_vite/src/components/CrimeMap.vue
@@ -177,8 +177,14 @@ export default {
 
 <style scoped>
 .map-container {
-  width: 100%;
-  height: 100vh;
+  width: 102vw; /* Slightly larger than the viewport */
+  height: 102vh; /* Slightly larger than the viewport */
+  margin: 0;
+  padding: 0;
+  touch-action: none; /* Prevent dragging */
+  position: relative; /* Ensure it stays within the parent container */
+  left: -1vw; /* Center the map by shifting it left */
+  top: 0vh; /* Center the map by shifting it up */
 }
 
 .location-button {
@@ -205,7 +211,7 @@ export default {
   right: 20px;
   padding: 12px 16px;
   font-size: 24px;
-  background-color: #28a745;
+  background-color: #007bff;
   color: #fff;
   border: none;
   border-radius: 50%;
@@ -214,7 +220,7 @@ export default {
 }
 
 .plus-button:hover {
-  background-color: #218838;
+  background-color: #0056b3;
 }
 
 .marker-menu {
@@ -242,3 +248,4 @@ export default {
   background-color: #f0f0f0;
 }
 </style>
+

--- a/streetsense/streetsense_frontend_vite/src/style.css
+++ b/streetsense/streetsense_frontend_vite/src/style.css
@@ -25,9 +25,7 @@ a:hover {
 body {
   margin: 0;
   display: flex;
-  place-items: center;
-  min-width: 320px;
-  min-height: 100vh;
+  flex-direction: column;
 }
 
 h1 {
@@ -59,10 +57,10 @@ button:focus-visible {
 }
 
 #app {
-  max-width: 1280px;
-  margin: 0 auto;
-  padding: 2rem;
-  text-align: center;
+  width: 100%;
+  height: 102%;
+  display: flex;
+  flex-direction: column;
 }
 
 @media (prefers-color-scheme: light) {
@@ -76,4 +74,20 @@ button:focus-visible {
   button {
     background-color: #f9f9f9;
   }
+}
+
+.map-container {
+  width: 100vw;
+  height: 100vh;
+  margin: 0;
+  padding: 0;
+}
+
+html, body {
+  margin: 0;
+  padding: 0;
+  width: 100vw;
+  height: 100vh;
+  overflow: hidden;
+  touch-action: none; /* Prevent dragging */
 }


### PR DESCRIPTION
Tried to fix some functionality that I had with mobile. Forced map to go to edges of screens and stopped a bug where users could drag buttons, revealing white background behind app. 

Also changed + button to match location button.