### PR TITLE
Allow users to undo markers in popup modal

### DIFF
--- a/src/components/CrimeMap.vue
+++ b/src/components/CrimeMap.vue
@@ -434,6 +434,13 @@ export default {
         onConfirm() {
           close()
         },
+        onDelete() {
+          const lastMarker = markers.value[markers.value.length - 1];
+          if (lastMarker) {
+            deleteMarker(lastMarker.id);
+          }
+          close();
+        }
       },
       slots: {
         default: `
@@ -626,6 +633,20 @@ export default {
       }
     };
 
+    const deleteMarker = async (markerId) => {
+      try {
+        await axios.delete(`/api/reports/${markerId}/`);
+        // Remove the marker from the local state
+        markers.value = markers.value.filter(marker => marker.id !== markerId);
+        // Close the info window
+        openMarker.value = null;
+        // Update the heatmap
+        updateHeatmap();
+      } catch (error) {
+        console.error('Error deleting marker:', error);
+      }
+    };
+
     return {
       mapCenter,
       mapOptions,
@@ -666,6 +687,7 @@ export default {
       markerTimeFilter,
       markerFadeEnabled,
       isMarkerWithinTimeFilter,
+      deleteMarker,
     };
   },
 };

--- a/src/components/ModalConfirmPlainCss.vue
+++ b/src/components/ModalConfirmPlainCss.vue
@@ -7,6 +7,7 @@
 
   const emit = defineEmits<{
     (e: 'confirm'): void
+    (e: 'delete'): void
   }>()
   </script>
 
@@ -18,9 +19,14 @@
       content-transition="vfm-fade"
     >
       <slot />
-      <button @click="emit('confirm')">
-        Ok
-      </button>
+      <div class="buttons">
+        <button @click="emit('delete')">
+          Undo
+        </button>
+        <button @click="emit('confirm')">
+          Ok
+        </button>
+      </div>
     </VueFinalModal>
   </template>
 
@@ -59,6 +65,18 @@
   }
   .dark .confirm-modal-content {
     background: #000;
+  }
+
+  .buttons {
+    display: flex;
+    justify-content: space-between;
+    width: 100%;
+    margin-top: .5rem;
+    margin-bottom: -.5rem;
+  }
+
+  .buttons button {
+    margin: 0;
   }
 
   /* Media query for mobile devices */


### PR DESCRIPTION
Created delete marker function.
Added to popup modal so only user who makes the marker can delete it.

Renamed to "Undo" to make it more intuitive for users. 

![image](https://github.com/user-attachments/assets/a0e4a4f5-f428-412f-bca6-14909bb74e1f)
